### PR TITLE
Align headers in report views

### DIFF
--- a/tt/cli.py
+++ b/tt/cli.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 import dateparser
-from tabulate import tabulate
+import tabulate
 
 import tt
 from tt.exc import ParseError
@@ -24,9 +24,11 @@ log = logging.getLogger('tt.cli')
 DEFAULT_REPORT_START = "midnight"
 DEFAULT_REPORT_END = "tomorrow at midnight"
 DATEPARSER_SETTINGS = {'TO_TIMEZONE': 'UTC', 'RETURN_AS_TIMEZONE_AWARE': True}
-DEFAULT_TABLE_FORMAT = 'simple'
+DEFAULT_TABLE_FORMAT = 'fancy_grid'
 DEFAULT_TABLE_HEADER_FORMATTER = str.capitalize
 APP_DATA_DIR = "~/.timetrack2"
+
+tabulate.PRESERVE_WHITESPACE = True
 
 
 def main(argv=None):
@@ -284,7 +286,7 @@ def _make_table(rows, headers):
 
     table = [[convert(c) for c in r] for r in rows]
 
-    return tabulate(
+    return tabulate.tabulate(
         table, headers=format_headers(headers), tablefmt=DEFAULT_TABLE_FORMAT)
 
 

--- a/tt/service.py
+++ b/tt/service.py
@@ -157,7 +157,7 @@ class TimerService(object):
                 str(d.date())
                 for d in tt.datetime.range_weekdays(week_start, week_end)
             ]
-            headers = ['task name'] + dates + ['Total']
+            headers = [" " * 16] + dates + ['Total']
             rows = []
             for task in weekly_data:
                 log.debug('Columns for task %s %s', task,
@@ -177,9 +177,9 @@ class TimerService(object):
                     seconds=sum([
                         c.total_seconds() for c in r
                         if isinstance(c, timedelta)
-                    ]) or 0) for r in zip(*rows)
+                    ]) or 0) or None for r in zip(*rows)
             ][1:]
-            totals = totals or [timedelta(0)] * 7
+            totals = totals or [None] * 6
 
             log.debug("len totals %d, totals %s", len(totals), totals)
 

--- a/tt/test/test_service.py
+++ b/tt/test/test_service.py
@@ -206,7 +206,7 @@ def test_report(agg, mocker, timer_service):
         timer_service.report(range_begin=range_begin, range_end=range_end))[0]
 
     expected_header = [
-        'task name',
+        ' ' * 16,
         '2018-02-05',
         '2018-02-06',
         '2018-02-07',
@@ -228,12 +228,9 @@ def test_report(agg, mocker, timer_service):
         timedelta(hours=6), None, None,
         timedelta(hours=13)
     ], [
-        'TOTAL',
-        timedelta(0),
+        'TOTAL', None,
         timedelta(hours=8),
-        timedelta(hours=8),
-        timedelta(0),
-        timedelta(0),
+        timedelta(hours=8), None, None,
         timedelta(hours=16)
     ]]
 


### PR DESCRIPTION
This PR adds a dummy header value on the first column consisting of 16 blank spaces, which when combined with telling the tabulate package to not strip whitespace, cause *most* weeks to align properly, providing task names are under 16 characters, which should be reasonable, even though we allow for 24.

fixes #39 