### PR TITLE
BUGFIX: Use local time for column headers in aggregate_by_task_date

### DIFF
--- a/doc/sources/changelog.rst
+++ b/doc/sources/changelog.rst
@@ -5,7 +5,7 @@ Product Changelog
 -----------
 
  * [ ] Fix: Use in-memory database during development
- * [ ] Fix: Timezone issue while grouping records in reporting views
+ * [X] Fix: Timezone issue while grouping records in reporting views
  * [X] Fix: CLI should always refer to times in local timezone
  * [X] Enancement: Major build system refactoring
  * [ ] New: Support for editing timer records

--- a/tt/timer.py
+++ b/tt/timer.py
@@ -7,6 +7,7 @@ import logging
 
 from sqlalchemy.orm.exc import NoResultFound
 
+from tt.datetime import local_time
 from tt.exc import ValidationError
 from tt.orm import Task, Timer
 from tt.sql import transaction
@@ -190,6 +191,7 @@ def aggregate_by_task_date(start, end):
     with transaction() as session:
         for timer in session.query(Timer).filter(start < Timer.start,
                                                  Timer.start <= end).all():
-            data[timer.task.name][timer.start.date()] += timer.elapsed
+            data[timer.task.name][local_time(
+                timer.start).date()] += timer.elapsed
 
     return data


### PR DESCRIPTION
When aggregating records by task and date, the key used for the record
is based on the `date()` of the timer's start timestamp.  Since the
timer is retrieved as an aware datetime object in UTC, if the UTC date
is different from the local date, the record was added to the incorrect
time bucket.

This forces a local time conversion on the timestamp before taking the
date, which will correctly categorize the records.

fixes #59 